### PR TITLE
allow ellipsis option to be empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = function fixedWidthString(str, width, options){
   }
 
   var parts = str.split(ANSI_REGEXP);
-  var ellipsis = options.ellipsis || '\u2026';  // '…'
+  var ellipsis = options.ellipsis === undefined ? '\u2026' : options.ellipsis;  // '…'
   var ellipsisWoAnsi = stripAnsi(ellipsis);
   var result = '';
 


### PR DESCRIPTION
Thanks for the project. Have a request to generate a fixed width file and there's little out there to help build something clean that I see -- aside from this project which will be very helpful. For the request, I needed to be able to override the ellipsis option so it's an empty string: `{ ellipsis: '' }`

You probably haven't thought about this in years so if this gets ignored I totally get it however to get the option to accept an empty string I only needed to modify one line, all tests are passing, etc, etc so figured I'd create a pull request.

Thanks again. 